### PR TITLE
Pin pydantic to 1.* to avoid rust libraries

### DIFF
--- a/charms/volcano-admission/requirements.txt
+++ b/charms/volcano-admission/requirements.txt
@@ -1,4 +1,5 @@
 ops >= 2.1.1,<3.0.0
 jinja2
 lightkube
+pydantic==1.*
 git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@61e9f278fc8c8119b1d4810ac39e2275be58e9ce#subdirectory=ops


### PR DESCRIPTION
the volcano-admission charm fails to build without rust libraries necessary to build 2.* pydantic.  Pin pydantic for the time being