### PR TITLE
build amd64 and arm64 builds independently

### DIFF
--- a/charms/volcano-admission/charmcraft.yaml
+++ b/charms/volcano-admission/charmcraft.yaml
@@ -6,14 +6,19 @@ bases:
   - build-on:
     - name: ubuntu
       channel: "22.04"
-    - name: ubuntu
-      channel: "20.04"
+      architectures: ["amd64"]
     run-on:
     - name: ubuntu
       channel: "22.04"
-      architectures:
-        - amd64
-        - arm64
+      architectures: ["amd64"]
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["arm64"]
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["arm64"]
 parts:
   charm:
     build-packages: [git]

--- a/charms/volcano-controllers/charmcraft.yaml
+++ b/charms/volcano-controllers/charmcraft.yaml
@@ -6,14 +6,19 @@ bases:
   - build-on:
     - name: ubuntu
       channel: "22.04"
-    - name: ubuntu
-      channel: "20.04"
+      architectures: ["amd64"]
     run-on:
     - name: ubuntu
       channel: "22.04"
-      architectures:
-        - amd64
-        - arm64
+      architectures: ["amd64"]
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["arm64"]
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["arm64"]
 parts:
   charm:
     prime: []

--- a/charms/volcano-scheduler/charmcraft.yaml
+++ b/charms/volcano-scheduler/charmcraft.yaml
@@ -6,14 +6,19 @@ bases:
   - build-on:
     - name: ubuntu
       channel: "22.04"
-    - name: ubuntu
-      channel: "20.04"
+      architectures: ["amd64"]
     run-on:
     - name: ubuntu
       channel: "22.04"
-      architectures:
-        - amd64
-        - arm64
+      architectures: ["amd64"]
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["arm64"]
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: ["arm64"]
 parts:
   charm:
     prime:


### PR DESCRIPTION
Volcano charms should be built with arm64 and amd64 builds independently 