### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,13 +6,13 @@ on:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@7aa0f7a606f182bd03a7adb28e0d710216101ca5 # main
     with:
       fail-on-error: "true"
 
   lint-unit:
     name: Lint Unit
-    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@6ee58c37d404effad4598ce7b523dbaf0cb99285 # main
     needs:
       - call-inclusive-naming-check
     with:
@@ -29,7 +29,7 @@ jobs:
           - volcano-scheduler
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Install and prepare LXD snap environment
       run: |
@@ -60,14 +60,14 @@ jobs:
         sudo charmcraft pack -p charms/${{ matrix.charm }}
 
     - name: Upload charm artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ matrix.charm }}
         path: ./*.charm
 
     - name: Upload debug artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: charmcraft-logs
         path: /home/runner/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log
@@ -86,10 +86,10 @@ jobs:
         juju: ["3.1/stable"]
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
+      uses: charmed-kubernetes/actions-operator@ea90ed489690bf3b1c1fcca6ac5f9edab70aecb0 # main
       with:
         provider: microk8s
         channel: ${{ matrix.microk8s }}
@@ -101,15 +101,15 @@ jobs:
 
     # download each of the above built charms
     - name: Download volcano-admission charm
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: volcano-admission
     - name: Download volcano-controllers charm
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: volcano-controllers
     - name: Download volcano-scheduler charm
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: volcano-scheduler
 
@@ -162,7 +162,7 @@ jobs:
       run: sg snap_microk8s -c "juju debug-log --replay --no-tail -i volcano-controllers" | tee tmp/unit-volcano-controllers-0.log
     - name: Upload debug artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: test-run-artifacts
         path: tmp


### PR DESCRIPTION
Pin all GitHub Actions to their commit SHAs to improve supply chain security.

This prevents:
- Compromised tags from injecting malicious code
- Unexpected behavior from mutable references
- Supply chain attacks via action tag manipulation