### PR TITLE
fix: add nosec annotations for bandit HIGH findings

### DIFF
--- a/charms/volcano-admission/src/manifests.py
+++ b/charms/volcano-admission/src/manifests.py
@@ -48,7 +48,7 @@ class Manifests:
             "Values": self._config,
             "Release": {"Charm": self.application, "Namespace": self.namespace},
         }
-        env = Environment(loader=FileSystemLoader("/"))
+        env = Environment(loader=FileSystemLoader("/")) # nosec B701
         env.filters["regexMatch"] = _regex_match
         for _ in templates:
             rendered = env.get_template(str(_.resolve())).render(context)


### PR DESCRIPTION
## Summary

Add inline `# nosec` annotations for intentional security patterns flagged by the new bandit SAST workflow (`-lll`, HIGH severity only).

These are all documented exceptions — not actual security vulnerabilities:

| Finding | Annotation | Rationale |
|---------|-----------|-----------|
| B103 | `# nosec B103` | chmod 0o777 in upstream library code |
| B202 | `# nosec B202` | `tarfile.extractall` from trusted upstream release artifacts |
| B324 | `# nosec B324` | MD5 used for content hashing, not security |
| B501 | `# nosec B501` | `verify=False` used for internal cluster communication |
| B602 | `# nosec B602` | `subprocess(shell=True)` with trusted/controlled input |
| B701 | `# nosec B701` | Jinja2 autoescape disabled for non-HTML template generation |

## Context
Companion to the SAST workflows PR. Once both are merged, the bandit workflow will pass cleanly.